### PR TITLE
app_config: Added i18n extension to Jinja2 template renderer by default

### DIFF
--- a/tg/configuration/app_config.py
+++ b/tg/configuration/app_config.py
@@ -8,7 +8,7 @@ from copy import copy, deepcopy
 import mimetypes
 from collections import MutableMapping as DictMixin
 
-from tg.i18n import ugettext, get_lang
+from tg.i18n import ugettext, ungettext, get_lang
 
 from tg.support.middlewares import SessionMiddleware, CacheMiddleware
 from tg.support.middlewares import StaticsMiddleware
@@ -271,7 +271,7 @@ class AppConfig(Bunch):
             self.package_name = self.package.__name__
         except AttributeError:
             self.package_name = None
-        
+
         log.debug("Initializing configuration, package: '%s'", self.package_name)
         conf = global_conf.copy()
         conf.update(app_conf)
@@ -584,6 +584,10 @@ double check that you have base_config['beaker.session.secret'] = 'mysecretsecre
         if not 'jinja_extensions' in self :
             self.jinja_extensions = []
 
+        # Add i18n extension by default
+        if not "jinja2.ext.i18n" in self.jinja_extensions:
+            self.jinja_extensions.append("jinja2.ext.i18n")
+
         if not 'jinja_filters' in self:
             self.jinja_filters = {}
 
@@ -619,6 +623,9 @@ double check that you have base_config['beaker.session.secret'] = 'mysecretsecre
 
         # Jinja's unable to request c's attributes without strict_c
         config['tg.strict_tmpl_context'] = True
+
+        # Add gettext functions to the jinja environment
+        config['tg.app_globals'].jinja2_env.install_gettext_callables(ugettext, ungettext)
 
         self.render_functions.jinja = render_jinja
 
@@ -1132,7 +1139,7 @@ double check that you have base_config['beaker.session.secret'] = 'mysecretsecre
 
             if global_conf is None:
                 global_conf = {}
-            
+
             # Configure the Application environment
             if load_environment:
                 load_environment(global_conf, app_conf)


### PR DESCRIPTION
see pull request #36

again, this patch has not been tested properly. I've tried to get the coverage tests to work but some of them failed when using nosetests.
