### PR TITLE
make _navigate_tw2form_children() actually navigate children

### DIFF
--- a/tg/validation.py
+++ b/tg/validation.py
@@ -19,10 +19,9 @@ except ImportError: #pragma: no cover
 def _navigate_tw2form_children(w):
     if getattr(w, 'id', None):
         yield w
-    else:
-        for c in getattr(w, 'children', []):
-            for cc in _navigate_tw2form_children(c):
-                yield cc
+    for c in getattr(w, 'children', []):
+        for cc in _navigate_tw2form_children(c):
+            yield cc
 
 class TGValidationError(Exception):
     """Invalid data was encountered during validation.


### PR DESCRIPTION
The generator has to continue after the first yield, not skip over the
children. Not doing this may leave tmpl_context.form_errors empty on
validation errors.
