### PR TITLE
Support the trace_slowreqs.enable config switch.

### DIFF
--- a/tests/test_errorware.py
+++ b/tests/test_errorware.py
@@ -10,36 +10,62 @@ def simple_app(environ, start_response):
 
 
 class TestErrorReporterConfig(object):
-    def test_disable_all(self):
+
+    middleware_name = 'TraceErrorsMiddleware'
+
+    def test_enable_none(self):
         app = ErrorReporter(simple_app, {})
-        reporters = [r.__class__.__name__ for r in app.reporters]
-        assert 'EmailReporter' not in reporters
-        assert 'SentryReporter' not in reporters
+        assert app.__class__.__name__ == self.middleware_name
+        assert not app.reporters
 
     def test_enable_email(self):
-        app = ErrorReporter(simple_app, {}, error_email='user@somedomain.com')
-        reporters = [r.__class__.__name__ for r in app.reporters]
-        assert 'EmailReporter' in reporters
+        app = ErrorReporter(simple_app, {},
+            error_email='user@somedomain.com')
+        assert app.__class__.__name__ == self.middleware_name
+        assert any(r.__class__.__name__ == 'EmailReporter'
+            for r in app.reporters)
 
     def test_enable_sentry(self):
-        app = ErrorReporter(simple_app, {}, sentry_dsn='http://public:secret@example.com/1')
-        reporters = [r.__class__.__name__ for r in app.reporters]
-        assert 'SentryReporter' in reporters
+        app = ErrorReporter(simple_app, {},
+            sentry_dsn='http://public:secret@example.com/1')
+        assert app.__class__.__name__ == self.middleware_name
+        assert any(r.__class__.__name__ == 'SentryReporter'
+            for r in app.reporters)
+
+    def test_debug_mode(self):
+        app = ErrorReporter(simple_app, dict(debug='on'), enable=True,
+            error_email='user@somedomain.com')
+        assert app is simple_app
 
 
 class TestSlowReqsReporterConfig(object):
+
+    middleware_name = 'TraceSlowRequestsMiddleware'
+
     def test_disable_all(self):
         app = SlowReqsReporter(simple_app, {})
-        reporters = [r.__class__.__name__ for r in app.reporters]
-        assert 'EmailReporter' not in reporters
-        assert 'SentryReporter' not in reporters
+        assert app is simple_app
+
+    def test_enable_without_reporter(self):
+        app = SlowReqsReporter(simple_app, {}, enable=True)
+        assert app.__class__.__name__ == self.middleware_name
+        assert not app.reporters
 
     def test_enable_email(self):
-        app = SlowReqsReporter(simple_app, {}, error_email='user@somedomain.com')
-        reporters = [r.__class__.__name__ for r in app.reporters]
-        assert 'EmailReporter' in reporters
+        app = SlowReqsReporter(simple_app, {}, enable=True,
+            error_email='user@somedomain.com')
+        assert app.__class__.__name__ == self.middleware_name
+        assert any(r.__class__.__name__ == 'EmailReporter'
+            for r in app.reporters)
 
     def test_enable_sentry(self):
-        app = SlowReqsReporter(simple_app, {}, sentry_dsn='http://public:secret@example.com/1')
-        reporters = [r.__class__.__name__ for r in app.reporters]
-        assert 'SentryReporter' in reporters
+        app = SlowReqsReporter(simple_app, {}, enable=True,
+            sentry_dsn='http://public:secret@example.com/1')
+        assert app.__class__.__name__ == self.middleware_name
+        assert any(r.__class__.__name__ == 'SentryReporter'
+            for r in app.reporters)
+
+    def test_debug_mode(self):
+        app = SlowReqsReporter(simple_app, dict(debug='on'), enable=True,
+            error_email='user@somedomain.com')
+        assert app is simple_app

--- a/tg/error.py
+++ b/tg/error.py
@@ -6,79 +6,87 @@ log = logging.getLogger(__name__)
 
 def _turbogears_backlash_context(environ):
     tgl = environ.get('tg.locals')
-    return {'request':getattr(tgl, 'request', None)}
+    return {'request': getattr(tgl, 'request', None)}
 
 
 def ErrorHandler(app, global_conf, **errorware):
     """ErrorHandler Toggle
-    
+
     If debug is enabled, this function will return the app wrapped in
     the WebError ``EvalException`` middleware which displays
     interactive debugging sessions when a traceback occurs.
-    
+
     Otherwise, the app will be wrapped in the WebError
     ``ErrorMiddleware``, and the ``errorware`` dict will be passed into
     it. The ``ErrorMiddleware`` handles sending an email to the address
     listed in the .ini file, under ``email_to``.
-    
+
     """
-    try:
-        import backlash
-    except ImportError: #pragma: no cover
-        log.warning('backlash not installed, debug mode won\'t be available')
-        return app
 
     if asbool(global_conf.get('debug')):
-        app = backlash.DebuggedApplication(app, context_injectors=[_turbogears_backlash_context])
+
+        try:
+            import backlash
+        except ImportError:  #pragma: no cover
+            log.warning('backlash not installed,'
+                        ' debug mode won\'t be available')
+        else:
+            app = backlash.DebuggedApplication(
+                app, context_injectors=[_turbogears_backlash_context])
 
     return app
 
 
 def ErrorReporter(app, global_conf, **errorware):
-    try:
-        import backlash
-    except ImportError: #pragma: no cover
-        log.warning('backlash not installed, email tracebacks won\'t be available')
-        return app
-
-
-    reporters = []
-    if errorware.get('error_email'):
-        from backlash.tracing.reporters.mail import EmailReporter
-        reporters.append(EmailReporter(**errorware))
-
-    if errorware.get('sentry_dsn'):
-        from backlash.tracing.reporters.sentry import SentryReporter
-        reporters.append(SentryReporter(**errorware))
 
     if not asbool(global_conf.get('debug')):
-        app = backlash.TraceErrorsMiddleware(app, reporters,
-                                             context_injectors=[_turbogears_backlash_context])
+
+        reporters = []
+
+        if errorware.get('error_email'):
+            from backlash.tracing.reporters.mail import EmailReporter
+            reporters.append(EmailReporter(**errorware))
+
+        if errorware.get('sentry_dsn'):
+            from backlash.tracing.reporters.sentry import SentryReporter
+            reporters.append(SentryReporter(**errorware))
+
+        try:
+            import backlash
+        except ImportError:  #pragma: no cover
+            log.warning('backlash not installed,'
+                        ' email tracebacks won\'t be available')
+        else:
+            app = backlash.TraceErrorsMiddleware(
+                app, reporters,
+                context_injectors=[_turbogears_backlash_context])
 
     return app
 
 
 def SlowReqsReporter(app, global_conf, **errorware):
-    try:
-        import backlash
-    except ImportError: #pragma: no cover
-        log.warning('backlash not installed, slow requests reporting won\'t be available')
-        return app
 
-    reporters = []
-    if errorware.get('error_email'):
-        from backlash.tracing.reporters.mail import EmailReporter
-        reporters.append(EmailReporter(**errorware))
+    if errorware.get('enable') and not asbool(global_conf.get('debug')):
 
-    if errorware.get('sentry_dsn'):
-        from backlash.tracing.reporters.sentry import SentryReporter
-        reporters.append(SentryReporter(**errorware))
+        reporters = []
 
-    if not asbool(global_conf.get('debug')):
-        app = backlash.TraceSlowRequestsMiddleware(app, reporters, interval=errorware.get('interval', 25),
-                                                   exclude_paths=errorware.get('exclude', None),
-                                                   context_injectors=[_turbogears_backlash_context])
+        if errorware.get('error_email'):
+            from backlash.tracing.reporters.mail import EmailReporter
+            reporters.append(EmailReporter(**errorware))
+
+        if errorware.get('sentry_dsn'):
+            from backlash.tracing.reporters.sentry import SentryReporter
+            reporters.append(SentryReporter(**errorware))
+
+        try:
+            import backlash
+        except ImportError:  #pragma: no cover
+            log.warning('backlash not installed,'
+                        ' slow requests reporting won\'t be available')
+        else:
+            app = backlash.TraceSlowRequestsMiddleware(
+                app, reporters, interval=errorware.get('interval', 25),
+                exclude_paths=errorware.get('exclude', None),
+                context_injectors=[_turbogears_backlash_context])
 
     return app
-
-


### PR DESCRIPTION
Patch for making the trace_slowreqs.enable setting operational. I have kept the behavior that the middleware is activated even when no reporters are configured. Or should I modify the patch so that the middleware will be only activated when at least one reporter is configured?
