### PR TITLE
let LazyString support all underlying instance methods

### DIFF
--- a/tg/util.py
+++ b/tg/util.py
@@ -136,8 +136,8 @@ class LazyString(object):
     def __mod__(self, other):
         return self.eval() % other
 
-    def format(self, other):
-        return self.eval().format(other)
+    def __getattr__(self, attr):
+        return getattr(self.eval(), attr)
 
 
 def lazify(func):


### PR DESCRIPTION
Hi, I just found LazyString doesn't support str/unicode.lower(). This change should support all underlying instance methods.