### PR TITLE
jsonify: raise error when serializing detached SA instance

### DIFF
--- a/tests/test_jsonify_sqlalchemy.py
+++ b/tests/test_jsonify_sqlalchemy.py
@@ -1,4 +1,4 @@
-from nose.tools import raises
+from nose.tools import assert_raises
 from tg import jsonify
 import json
 
@@ -102,3 +102,10 @@ else:
         result = json.loads(encoded)
         assert result == expected, encoded
 
+    def test_detached_saobj():
+        s = create_session()
+        t = s.query(Test1).get(1)
+        # ensure it can be serialized now
+        jsonify.encode(t)
+        s.expunge(t)
+        assert_raises(jsonify.JsonEncodeError, lambda: jsonify.encode(t))

--- a/tg/jsonify.py
+++ b/tg/jsonify.py
@@ -122,6 +122,10 @@ class JSONEncoder(_JSONEncoder, GlobalConfigurable):
         elif isinstance(obj, decimal.Decimal):
             return float(obj)
         elif is_saobject(obj):
+            if sqlalchemy.inspect(obj).detached:
+                raise JsonEncodeError(
+                        "SQLAlchemy instance '%r' must be attached "
+                        "to a session." % obj)
             props = {}
             for key in obj.__dict__:
                 if not key.startswith('_sa_'):


### PR DESCRIPTION
SQLAlchemy instances that were created in a transaction that has ended
meanwhile would otherwise return empty dicts when serialized to JSON.