### PR TITLE
py3: make LazyString objects iterable

### DIFF
--- a/tg/util/lazystring.py
+++ b/tg/util/lazystring.py
@@ -23,6 +23,9 @@ class LazyString(object):
     def __mod__(self, other):
         return self.eval() % other
 
+    def __iter__(self):
+        return iter(self.eval())
+
     def __getattr__(self, attr):
         return getattr(self.eval(), attr)
 


### PR DESCRIPTION
This is necessary so that Genshi > 0.7 can render LazyString objects
with Python 3.