### PR TITLE
[ci skip] Get more Open Source Helpers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ TurboGears
 .. image:: https://travis-ci.org/TurboGears/tg2.png?branch=development
     :target: https://travis-ci.org/TurboGears/tg2
 
-.. image:: https://coveralls.io/repos/TurboGears/tg2/badge.png?branch=development 
+.. image:: https://coveralls.io/repos/TurboGears/tg2/badge.png?branch=development
     :target: https://coveralls.io/r/TurboGears/tg2?branch=development
 
 .. image:: https://img.shields.io/pypi/v/TurboGears2.svg
@@ -15,6 +15,9 @@ TurboGears
 
 .. image:: https://img.shields.io/pypi/l/TurboGears2.svg
     :target: https://pypi.python.org/pypi/TurboGears2
+
+.. image:: https://www.codetriage.com/turbogears/tg2/badges/users.svg
+    :target: https://www.codetriage.com/turbogears/tg2
 
 .. image:: https://img.shields.io/twitter/follow/turbogearsorg.svg?style=social&label=Follow
     :target: https://twitter.com/turbogearsorg
@@ -27,8 +30,8 @@ Support and Documentation
 -------------------------
 
 See the `TurboGears website <http://www.turbogears.org/>`_ to get
-a quick overview of the framework or visit the 
-`TurboGears Documentation <http://turbogears.readthedocs.org/>`_ 
+a quick overview of the framework or visit the
+`TurboGears Documentation <http://turbogears.readthedocs.org/>`_
 
 License
 -------


### PR DESCRIPTION
[CodeTriage](https://www.codetriage.com/) is an app I have maintained
for the past 4-5 years with the goal of getting people involved in
Open Source projects like this one. The app sends subscribers a random
open issue for them to help "triage". For some languages you can also
suggested areas to add documentation.

The initial approach was inspired by seeing the work of the small
core team spending countless hours asking "what version was
this in" and "can you give us an example app". The idea is to
outsource these small interactions to a huge team of volunteers
and let the core team focus on their work.

I want to add a badge to the README of this project. The idea is to
provide an easy link for people to get started contributing to this
project. A badge indicates the number of people currently subscribed
to help the repo. The color is based off of open issues in the project.

Here are some examples of other projects that have a badge in their
README:

- https://github.com/crystal-lang/crystal
- https://github.com/rails/rails
- https://github.com/codetriage/codetriage

Thanks for building open source software, I would love to help you find some helpers.