### PR TITLE
fix for python 3.8: DeprecationWarning: Using or importing the ABCs f…

### DIFF
--- a/tg/configuration/tgconfig.py
+++ b/tg/configuration/tgconfig.py
@@ -1,6 +1,9 @@
 """Defines and initialises what is exposed as tg.config"""
 from copy import deepcopy
-from collections import MutableMapping as DictMixin
+try:
+    from collections.abc import MutableMapping as DictMixin
+except ImportError:  # for python versions below 3.3
+    from collections import MutableMapping as DictMixin
 from tg.request_local import config as reqlocal_config
 from tg.configuration.utils import get_partial_dict
 from tg.util import Bunch


### PR DESCRIPTION
…rom 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working