### PR TITLE
option i18n.notrans for language alias of C locale

### DIFF
--- a/tg/appwrappers/i18n.py
+++ b/tg/appwrappers/i18n.py
@@ -19,6 +19,9 @@ class I18NApplicationWrapper(ApplicationWrapper):
           detection is enabled or disabled. If this is set and language detection is
           dislabled, the application will consider that all gettext wrapped strings must
           be translated to this language.
+        - ``i18n.self_translated_langs``: List of comma or space separated languages
+          which are considered self translating, i.e. they do not need a translation file
+          and all strings are returned untranslated.
         - ``i18n.lang_session_key``: Session key from which to read the saved language
           (``tg_lang`` by default).
         - ``i18n.no_session_touch``: Avoid causing a session save when reading it to retrieve the

--- a/tg/configurator/components/i18n.py
+++ b/tg/configurator/components/i18n.py
@@ -21,6 +21,11 @@ class I18NConfigurationComponent(ConfigurationComponent):
                             pages will be served as they were in ``i18n.lang`` value.
         * ``localedir``: Where to find translation catalogs.
                          By default it's project root/i18n
+        * ``i18n.self_translated_langs``: List of comma or space separated
+                                          languages which are considered self
+                                          translating, i.e. they do not need a
+                                          translation file and all strings are
+                                          returned untranslated.
 
     Refer to :class:`.I18NApplicationWrapper` for additional options
     in supporting i18n.
@@ -30,7 +35,8 @@ class I18NConfigurationComponent(ConfigurationComponent):
     def get_defaults(self):
         return {
             'i18n.lang': None,
-            'i18n.enabled': True
+            'i18n.enabled': True,
+            'i18n.self_translated_langs': None
         }
 
     def get_actions(self):


### PR DESCRIPTION
Correctly terminate the translator fallback chain for the _C_ locale (as _gettext.find() does). Use config option i18n.notrans as a language code alias for the _C_ locale. E.g., when there is no _en_ translation file, since all strings are already in English,

```ini
i18n.notrans = en
```

terminates the translators for an Accept-Language header of

```
Accept-Language: ru,en,fr,de
```

after _ru_:

```python
supported_languages = ['ru']
```

instead of setting up the translator incorrectly as:

```python
supported_languages = ['ru', 'fr', 'de']
```
